### PR TITLE
Rename USART1_Txcomplete_Handler to USART1_TxComplete_Handler.

### DIFF
--- a/Device/HDSC/hc32f334/Source/GCC/startup_hc32f334.S
+++ b/Device/HDSC/hc32f334/Source/GCC/startup_hc32f334.S
@@ -218,7 +218,7 @@ __Vectors:
                 .long       CMP3_Handler
                 .long       I2C_Handler
                 .long       USART1_Handler
-                .long       USART1_Txcomplete_Handler
+                .long       USART1_TxComplete_Handler
                 .long       SPI_Handler
                 .long       TMRA_5_Ovf_Udf_Handler
                 .long       TMRA_5_Cmp_Handler


### PR DESCRIPTION
Rename USART1_Txcomplete_Handler to USART1_TxComplete_Handler in GCC/startup_hc32f334.S.